### PR TITLE
LPS-003 Document Expense Type story (AC + Test Map)

### DIFF
--- a/docs/lcap-stories/LPS-003-expense-type.md
+++ b/docs/lcap-stories/LPS-003-expense-type.md
@@ -1,0 +1,47 @@
+# LPS-003 Categorize Expense Requests
+
+## Story
+
+As an employee submitting an expense, I want to categorize my request so the accounting team can classify it and the right reviewer gets the work.
+
+## Acceptance Criteria
+
+### AC1. Expense Type picklist
+The expense form shows a dropdown labeled "Expense Type" with three values:
+
+- Travel Expenses
+- Educational Expenses
+- Office Expenses
+
+### AC2. Required field
+Submitting without selecting an Expense Type shows a field-level validation error and blocks the submission.
+
+### AC3. Routing to a dedicated reviewer *(future delivery)*
+The first review task is assigned directly to Ana Buchmann from accounting, not to the generic Expense Approver role.
+
+This AC is **not** covered by the current change. It needs a workflow edit that we discuss in the talk but do not ship in this PR.
+
+### AC4. Reviewer sees the type
+When the assigned reviewer opens the task, the selected Expense Type is visible on the request detail.
+
+### AC5. Closed picklist
+The field rejects any value outside the three predefined options. Custom or free-text input is not accepted.
+
+## Test Map
+
+Each AC maps to a Playwright test in `modules/test/playwright/tests/workspaces/liferay-reimbursement-workspace/main/expenseRequest.spec.ts`:
+
+| AC | Test name | Type |
+|---|---|---|
+| AC1 | `can submit a reimbursement request` (updated) | happy path |
+| AC2 | `can not submit without an expense type` | validation |
+| AC4 | covered by the existing approver flow once the type is filled | flow |
+| AC5 | enforced by the picklist field type at the platform level. covered implicitly by AC1 + AC2 | platform |
+| AC3 | not yet covered, depends on a workflow change in a follow-up story | n/a |
+
+## References
+
+The exports under `workspaces/liferay-reimbursement-workspace/client-extensions/` follow Liferay's Site Initializer and Batch Engine formats. See:
+
+- [Site Initializer](https://learn.liferay.com/dxp/latest/en/site-building/developer-guide/creating-site-initializers.html) for the layout and asset structure.
+- [Batch Engine](https://learn.liferay.com/dxp/latest/en/headless-delivery/batch-engine.html) for the JSON import format used by the `liferay-reimbursement-batch` client extension.


### PR DESCRIPTION
## What this PR does

Adds the acceptance criteria and test map for the Expense Type categorization story, before any code goes in.

This is **step 1** of the LPS-003 delivery, split into three PRs that mirror the governance framework from the talk.

## Story summary

Employees need to categorize each reimbursement request as Travel, Educational, or Office, so accounting can classify spend and routing logic has something to key off.

Full ACs and the Test Map are in [\`docs/lcap-stories/LPS-003-expense-type.md\`](../blob/lps-003-step1-ac/docs/lcap-stories/LPS-003-expense-type.md).

AC3 (route initial review to Ana Buchmann) is **out of scope** for this delivery. We discuss it but do not change the workflow.

## Next PRs

- **Step 2** \`lps-003-step2-config\` adds the picklist, the new object field, and the form input. Exported from the low-code editor.
- **Step 3** \`lps-003-step3-tests\` adds the Playwright coverage for AC1 and AC2.

## References

- Site Initializer docs: https://learn.liferay.com/dxp/latest/en/site-building/developer-guide/creating-site-initializers.html
- Batch Engine docs: https://learn.liferay.com/dxp/latest/en/headless-delivery/batch-engine.html