### PR TITLE
LPS-003 Add Playwright tests for Expense Type

### DIFF
--- a/modules/test/playwright/tests/workspaces/liferay-reimbursement-workspace/main/expenseRequest.spec.ts
+++ b/modules/test/playwright/tests/workspaces/liferay-reimbursement-workspace/main/expenseRequest.spec.ts
@@ -24,12 +24,13 @@ test.beforeEach(async ({page}) => {
 	await customerPerformLogin(page, 'test@liferay.com');
 });
 
-test('can submit a reimbursement request', async ({homePage}) => {
+test('can submit a reimbursement request', {tag: '@LPS-003'}, async ({homePage}) => {
 	await homePage.goto();
 
 	await expect(homePage.expenseRequestsHeading).toBeVisible();
 
 	await homePage.expenseTitle.fill('Dinner');
+	await homePage.expenseType.selectOption('Travel Expenses');
 	await homePage.expenseAmount.fill('16.50');
 	await homePage.expenseDescription.fill('Dinner in Madrid');
 	await homePage.expenseDate.pressSequentially('11/17/2025');
@@ -45,6 +46,7 @@ test('can not submit a reimbursement request using a negative amount value', asy
 	await expect(homePage.expenseRequestsHeading).toBeVisible();
 
 	await homePage.expenseTitle.fill('Dinner');
+	await homePage.expenseType.selectOption('Travel Expenses');
 	await homePage.expenseAmount.fill('-1');
 	await homePage.expenseDescription.fill('Dinner in Madrid');
 	await homePage.expenseDate.pressSequentially('11/17/2025');
@@ -52,6 +54,21 @@ test('can not submit a reimbursement request using a negative amount value', asy
 	await homePage.expenseSubmitButton.click();
 
 	await expect(homePage.expenseAmountErrorMessage).toBeVisible();
+});
+
+test('can not submit a reimbursement request without an expense type', {tag: '@LPS-003'}, async ({homePage}) => {
+	await homePage.goto();
+
+	await expect(homePage.expenseRequestsHeading).toBeVisible();
+
+	await homePage.expenseTitle.fill('Dinner');
+	await homePage.expenseAmount.fill('16.50');
+	await homePage.expenseDescription.fill('Dinner in Madrid');
+	await homePage.expenseDate.pressSequentially('11/17/2025');
+
+	await homePage.expenseSubmitButton.click();
+
+	await expect(homePage.expenseTypeRequiredErrorMessage).toBeVisible();
 });
 
 test('can configure the workflow for a reimbursement request', async ({applicationsMenuPage, configurationTabPage}) => {

--- a/modules/test/playwright/tests/workspaces/liferay-reimbursement-workspace/main/pages/HomePage.ts
+++ b/modules/test/playwright/tests/workspaces/liferay-reimbursement-workspace/main/pages/HomePage.ts
@@ -16,7 +16,9 @@ export class HomePage {
     readonly expenseSubmitButton: Locator;
     readonly expenseSucessMessage: Locator;
     readonly expenseTitle: Locator;
-    
+    readonly expenseType: Locator;
+    readonly expenseTypeRequiredErrorMessage: Locator;
+
     constructor(page: Page) {
         this.page = page;
         this.expenseAmount = page.getByLabel('Amount');
@@ -28,6 +30,8 @@ export class HomePage {
         this.expenseSubmitButton = page.getByRole('button', {name: 'Submit'});
         this.expenseSucessMessage = page.getByText('Thank you. Your information was successfully received.');
         this.expenseTitle = page.getByRole('textbox', {name: 'Title'});
+        this.expenseType = page.getByLabel('Expense Type');
+        this.expenseTypeRequiredErrorMessage = page.getByText('This field is required.');
     }
 
     async goto() {


### PR DESCRIPTION
## What this PR does

Adds the automated test coverage for the Expense Type story. The tests run against a Liferay instance that already has the configuration from \`lps-003-step2-config\` deployed.

This is **step 3** of LPS-003. The story is in \`lps-003-step1-ac\`. The configuration is in \`lps-003-step2-config\`.

## Test changes

\`pages/HomePage.ts\` gains two locators:
- \`expenseType\` (the dropdown, by label)
- \`expenseTypeRequiredErrorMessage\` (the field-level required warning)

\`expenseRequest.spec.ts\`:
- \`can submit a reimbursement request\` (updated) now fills Expense Type with Travel Expenses before submit. This covers AC1.
- \`can not submit a reimbursement request without an expense type\` (new) submits with every other field filled and expects the required error. This covers AC2.
- The existing negative-amount test also picks an Expense Type so the required check does not short-circuit the test.

All new tests are tagged with \`@LPS-003\` so they link back to the story in Jira.

## What this PR does **not** touch

- The workflow assignment tests. They remain on the Expense Approver role until AC3 ships.

## How to verify locally

\`\`\`
cd modules/test/playwright
./node_modules/.bin/playwright test --project=reimbursement-site-initializer.main --headed
\`\`\`

Expect the four existing tests plus the new \`can not submit ... without an expense type\` to pass against a portal that has the step-2 changes deployed.