### PR TITLE
LPD-96916 Fix geolocation maps not rendering from duplicate API load

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -25,7 +25,6 @@ const MAP_CONFIG = {
 		CONTROLS.ZOOM,
 	],
 	geolocation: true,
-	position: {location: {}},
 };
 
 const getMapName = (name) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -59,29 +59,41 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 		Liferay.Maps.gmapsReady
 	) {
 		callback();
+
+		return;
 	}
-	else {
-		Liferay.namespace('Maps').onGMapsReady = function () {
-			Liferay.Maps.gmapsReady = true;
-			Liferay.fire('gmapsReady');
-		};
 
-		Liferay.once('gmapsReady', () => callback());
+	Liferay.namespace('Maps').onGMapsReady = function () {
+		Liferay.Maps.gmapsReady = true;
+		Liferay.fire('gmapsReady');
+	};
 
-		let apiURL = `${location.protocol}//maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady`;
+	Liferay.once('gmapsReady', () => callback());
 
-		if (googleMapsAPIKey) {
-			apiURL += '&key=' + googleMapsAPIKey;
-		}
-
-		let script = document.createElement('script');
-
-		script.setAttribute('src', apiURL);
-
-		document.head.appendChild(script);
-
-		script = null;
+	if (
+		Liferay.Maps.gmapsLoading ||
+		document.querySelector(
+			'script[src*="maps.googleapis.com/maps/api/js"][src*="callback=Liferay.Maps.onGMapsReady"]'
+		)
+	) {
+		return;
 	}
+
+	Liferay.Maps.gmapsLoading = true;
+
+	let apiURL = `${location.protocol}//maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady`;
+
+	if (googleMapsAPIKey) {
+		apiURL += '&key=' + googleMapsAPIKey;
+	}
+
+	let script = document.createElement('script');
+
+	script.setAttribute('src', apiURL);
+
+	document.head.appendChild(script);
+
+	script = null;
 };
 
 export function useGeolocation({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -121,14 +121,10 @@ export function useGeolocation({
 			const mapConfig = {
 				...MAP_CONFIG,
 				boundingBox: `#map_${instanceId}`,
+				position: {
+					location: value ? parseJSONValue(value) : {lat: 0, lng: 0},
+				},
 			};
-
-			if (value) {
-				mapConfig.position.location = parseJSONValue(value);
-			}
-			else {
-				mapConfig.position.location = {lat: 0, lng: 0};
-			}
 
 			const registerMapBase = (MapProvider, mapConfig) => {
 				mapRef.current = new MapProvider(mapConfig);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -63,7 +63,9 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 	}
 
 	Liferay.namespace('Maps').onGMapsReady = function () {
+		Liferay.Maps.gmapsLoading = false;
 		Liferay.Maps.gmapsReady = true;
+
 		Liferay.fire('gmapsReady');
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -89,6 +89,12 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 
 	let script = document.createElement('script');
 
+	script.addEventListener('error', (event) => {
+		Liferay.Maps.gmapsLoading = false;
+
+		event.currentTarget.remove();
+	});
+
 	script.setAttribute('src', apiURL);
 
 	document.head.appendChild(script);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Geolocation/useGeolocation.es.js
@@ -59,7 +59,7 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 	) {
 		callback();
 
-		return;
+		return undefined;
 	}
 
 	Liferay.namespace('Maps').onGMapsReady = function () {
@@ -69,7 +69,10 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 		Liferay.fire('gmapsReady');
 	};
 
-	Liferay.once('gmapsReady', () => callback());
+	Liferay.once('gmapsReady', callback);
+
+	const detachGMapsReadyListener = () =>
+		Liferay.detach('gmapsReady', callback);
 
 	if (
 		Liferay.Maps.gmapsLoading ||
@@ -77,7 +80,7 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 			'script[src*="maps.googleapis.com/maps/api/js"][src*="callback=Liferay.Maps.onGMapsReady"]'
 		)
 	) {
-		return;
+		return detachGMapsReadyListener;
 	}
 
 	Liferay.Maps.gmapsLoading = true;
@@ -101,6 +104,8 @@ const setupGoogleMaps = (googleMapsAPIKey, callback) => {
 	document.head.appendChild(script);
 
 	script = null;
+
+	return detachGMapsReadyListener;
 };
 
 export function useGeolocation({
@@ -118,6 +123,8 @@ export function useGeolocation({
 	const onPositionChangeRef = useRef(null);
 
 	useEffect(() => {
+		let detachGMapsReadyListener;
+
 		if (!disabled || viewMode) {
 			const mapConfig = {
 				...MAP_CONFIG,
@@ -156,8 +163,9 @@ export function useGeolocation({
 					break;
 
 				case MAP_PROVIDER.googleMaps:
-					setupGoogleMaps(googleMapsAPIKey, () =>
-						registerMapBase(MapGoogleMaps, mapConfig)
+					detachGMapsReadyListener = setupGoogleMaps(
+						googleMapsAPIKey,
+						() => registerMapBase(MapGoogleMaps, mapConfig)
 					);
 					break;
 
@@ -167,6 +175,8 @@ export function useGeolocation({
 		}
 
 		return () => {
+			detachGMapsReadyListener?.();
+
 			if (mapRef.current) {
 				mapRef.current.dispose();
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -29,11 +29,19 @@ beforeAll(() => {
 			CONTROLS: {},
 			register: jest.fn(),
 		},
+		Maps: {},
 		ThemeDisplay: {
 			getPathThemeImages: () => '',
 		},
 		detach: jest.fn(),
+		fire: jest.fn(),
+		namespace: jest.fn((name) => {
+			window.Liferay[name] = window.Liferay[name] || {};
+
+			return window.Liferay[name];
+		}),
 		on: jest.fn(),
+		once: jest.fn(),
 	};
 });
 
@@ -173,5 +181,143 @@ describe('Geolocation', () => {
 
 		expect(previousListener.removeListener).toHaveBeenCalledTimes(1);
 		expect(currentListener.removeListener).not.toHaveBeenCalled();
+	});
+});
+
+describe('Geolocation Google Maps loader', () => {
+	const gmapsScriptSelector =
+		'script[src*="maps.googleapis.com/maps/api/js"]';
+
+	const renderGoogleMapsField = (instanceId, name) =>
+		render(
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{editingLanguageId: 'en_US', pages: []}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<Geolocation
+							instanceId={instanceId}
+							mapProviderKey="GoogleMaps"
+							name={name}
+							onChange={jest.fn()}
+							value={{lat: 1, lng: 1}}
+						/>
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+	beforeEach(() => {
+		delete window.google;
+
+		window.Liferay.Maps = {};
+
+		document
+			.querySelectorAll(gmapsScriptSelector)
+			.forEach((script) => script.remove());
+	});
+
+	afterEach(() => {
+		document
+			.querySelectorAll(gmapsScriptSelector)
+			.forEach((script) => script.remove());
+	});
+
+	it('injects the Google Maps API script only once for two fields', () => {
+		render(
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{
+						editingLanguageId: 'en_US',
+						pages: [],
+					}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<>
+							<Geolocation
+								instanceId="first"
+								mapProviderKey="GoogleMaps"
+								name="geoFirst"
+								onChange={jest.fn()}
+								value={{lat: 1, lng: 1}}
+							/>
+
+							<Geolocation
+								instanceId="second"
+								mapProviderKey="GoogleMaps"
+								name="geoSecond"
+								onChange={jest.fn()}
+								value={{lat: 2, lng: 2}}
+							/>
+						</>
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+	});
+
+	it('re-injects the Google Maps API script after a failed load', () => {
+		renderGoogleMapsField('first', 'geoFirst');
+
+		const [script] = document.querySelectorAll(gmapsScriptSelector);
+
+		expect(script).toBeTruthy();
+		expect(window.Liferay.Maps.gmapsLoading).toBe(true);
+
+		script.dispatchEvent(new Event('error'));
+
+		expect(window.Liferay.Maps.gmapsLoading).toBe(false);
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(0);
+
+		renderGoogleMapsField('second', 'geoSecond');
+
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+	});
+});
+
+describe('Geolocation map configuration', () => {
+	it('builds an isolated position for each field', () => {
+		MapOpenStreetMap.mockClear();
+
+		render(
+			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
+				<FormProvider
+					initialState={{editingLanguageId: 'en_US', pages: []}}
+					reducers={[languageReducer]}
+				>
+					<PageProvider value={{pageIndex: 0}}>
+						<>
+							<Geolocation
+								instanceId="a"
+								mapProviderKey="OpenStreetMap"
+								name="geoA"
+								onChange={jest.fn()}
+								value={{lat: 1, lng: 1}}
+							/>
+
+							<Geolocation
+								instanceId="b"
+								mapProviderKey="OpenStreetMap"
+								name="geoB"
+								onChange={jest.fn()}
+								value={{lat: 2, lng: 2}}
+							/>
+						</>
+					</PageProvider>
+				</FormProvider>
+			</ConfigProvider>
+		);
+
+		const [firstConfig, secondConfig] = MapOpenStreetMap.mock.calls.map(
+			([config]) => config
+		);
+
+		expect(firstConfig.position.location).toEqual({lat: 1, lng: 1});
+		expect(secondConfig.position.location).toEqual({lat: 2, lng: 2});
+		expect(firstConfig.position).not.toBe(secondConfig.position);
 	});
 });

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -261,6 +261,30 @@ describe('Geolocation Google Maps loader', () => {
 		);
 
 		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+		expect(window.Liferay.once.mock.calls).toEqual([
+			['gmapsReady', expect.any(Function)],
+			['gmapsReady', expect.any(Function)],
+		]);
+	});
+
+	it('skips injection when a loader script is already in the document', () => {
+		const script = document.createElement('script');
+
+		script.setAttribute(
+			'src',
+			'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady'
+		);
+
+		document.head.appendChild(script);
+
+		renderGoogleMapsField('first', 'geoFirst');
+
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+		expect(window.Liferay.Maps.gmapsLoading).toBeUndefined();
+		expect(window.Liferay.once).toHaveBeenCalledWith(
+			'gmapsReady',
+			expect.any(Function)
+		);
 	});
 
 	it('re-injects the Google Maps API script after a failed load', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -227,6 +227,27 @@ describe('Geolocation Google Maps loader', () => {
 			.forEach((script) => script.remove());
 	});
 
+	it('clears the loading flag once the API is ready', () => {
+		renderGoogleMapsField('first', 'geoFirst');
+
+		expect(window.Liferay.Maps.gmapsLoading).toBe(true);
+
+		window.Liferay.Maps.onGMapsReady();
+
+		expect(window.Liferay.Maps.gmapsLoading).toBe(false);
+		expect(window.Liferay.Maps.gmapsReady).toBe(true);
+	});
+
+	it('detaches the gmapsReady listener when the field unmounts', () => {
+		const {unmount} = renderGoogleMapsField('first', 'geoFirst');
+
+		const [eventName, listener] = window.Liferay.once.mock.calls[0];
+
+		unmount();
+
+		expect(window.Liferay.detach).toHaveBeenCalledWith(eventName, listener);
+	});
+
 	it('injects the Google Maps API script only once for two fields', () => {
 		render(
 			<ConfigProvider value={{defaultLanguageId: 'en_US'}}>
@@ -267,26 +288,6 @@ describe('Geolocation Google Maps loader', () => {
 		]);
 	});
 
-	it('skips injection when a loader script is already in the document', () => {
-		const script = document.createElement('script');
-
-		script.setAttribute(
-			'src',
-			'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady'
-		);
-
-		document.head.appendChild(script);
-
-		renderGoogleMapsField('first', 'geoFirst');
-
-		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
-		expect(window.Liferay.Maps.gmapsLoading).toBeUndefined();
-		expect(window.Liferay.once).toHaveBeenCalledWith(
-			'gmapsReady',
-			expect.any(Function)
-		);
-	});
-
 	it('re-injects the Google Maps API script after a failed load', () => {
 		renderGoogleMapsField('first', 'geoFirst');
 
@@ -305,25 +306,24 @@ describe('Geolocation Google Maps loader', () => {
 		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
 	});
 
-	it('clears the loading flag once the API is ready', () => {
+	it('skips injection when a loader script is already in the document', () => {
+		const script = document.createElement('script');
+
+		script.setAttribute(
+			'src',
+			'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady'
+		);
+
+		document.head.appendChild(script);
+
 		renderGoogleMapsField('first', 'geoFirst');
 
-		expect(window.Liferay.Maps.gmapsLoading).toBe(true);
-
-		window.Liferay.Maps.onGMapsReady();
-
-		expect(window.Liferay.Maps.gmapsLoading).toBe(false);
-		expect(window.Liferay.Maps.gmapsReady).toBe(true);
-	});
-
-	it('detaches the gmapsReady listener when the field unmounts', () => {
-		const {unmount} = renderGoogleMapsField('first', 'geoFirst');
-
-		const [eventName, listener] = window.Liferay.once.mock.calls[0];
-
-		unmount();
-
-		expect(window.Liferay.detach).toHaveBeenCalledWith(eventName, listener);
+		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
+		expect(window.Liferay.Maps.gmapsLoading).toBeUndefined();
+		expect(window.Liferay.once).toHaveBeenCalledWith(
+			'gmapsReady',
+			expect.any(Function)
+		);
 	});
 });
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -277,6 +277,17 @@ describe('Geolocation Google Maps loader', () => {
 
 		expect(document.querySelectorAll(gmapsScriptSelector)).toHaveLength(1);
 	});
+
+	it('clears the loading flag once the API is ready', () => {
+		renderGoogleMapsField('first', 'geoFirst');
+
+		expect(window.Liferay.Maps.gmapsLoading).toBe(true);
+
+		window.Liferay.Maps.onGMapsReady();
+
+		expect(window.Liferay.Maps.gmapsLoading).toBe(false);
+		expect(window.Liferay.Maps.gmapsReady).toBe(true);
+	});
 });
 
 describe('Geolocation map configuration', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Geolocation/Geolocation.es.js
@@ -213,6 +213,9 @@ describe('Geolocation Google Maps loader', () => {
 
 		window.Liferay.Maps = {};
 
+		window.Liferay.detach.mockClear();
+		window.Liferay.once.mockClear();
+
 		document
 			.querySelectorAll(gmapsScriptSelector)
 			.forEach((script) => script.remove());
@@ -287,6 +290,16 @@ describe('Geolocation Google Maps loader', () => {
 
 		expect(window.Liferay.Maps.gmapsLoading).toBe(false);
 		expect(window.Liferay.Maps.gmapsReady).toBe(true);
+	});
+
+	it('detaches the gmapsReady listener when the field unmounts', () => {
+		const {unmount} = renderGoogleMapsField('first', 'geoFirst');
+
+		const [eventName, listener] = window.Liferay.once.mock.calls[0];
+
+		unmount();
+
+		expect(window.Liferay.detach).toHaveBeenCalledWith(eventName, listener);
 	});
 });
 

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -48,6 +48,12 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 
 			var script = document.createElement('script');
 
+			script.addEventListener('error', function (event) {
+				Liferay.Maps.gmapsLoading = false;
+
+				event.currentTarget.remove();
+			});
+
 			script.setAttribute('src', apiURL);
 
 			document.head.appendChild(script);

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -24,6 +24,7 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 >
 	<aui:script>
 		Liferay.namespace('Maps').onGMapsReady = function (event) {
+			Liferay.Maps.gmapsLoading = false;
 			Liferay.Maps.gmapsReady = true;
 
 			Liferay.fire('gmapsReady');

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -29,7 +29,15 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 			Liferay.fire('gmapsReady');
 		};
 
-		if (!Liferay.Maps.gmapsReady) {
+		if (
+			!Liferay.Maps.gmapsReady &&
+			!Liferay.Maps.gmapsLoading &&
+			!document.querySelector(
+				'script[src*="maps.googleapis.com/maps/api/js"][src*="callback=Liferay.Maps.onGMapsReady"]'
+			)
+		) {
+			Liferay.Maps.gmapsLoading = true;
+
 			var apiURL =
 				'<%= protocol %>' +
 				'://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96916

## What Is Being Fixed

A web content page with two geolocation fields rendered no map. Each field loaded the Google Maps JavaScript API on its own, so the script was injected twice and Google refused to render every map. Once rendering was restored, both maps showed the same location because every field mutated one shared position object.

This PR carries the four commits from liferay-bpm/liferay-portal#6414 by @SaurasishB and adds four review follow-up commits that harden that fix.

## How It Is Being Fixed

The original commits guard the API load behind a shared gmapsLoading flag plus a check for an already injected loader script, recover from a failed load by clearing the flag and removing the dead script, and build a per-field position object instead of mutating a module level constant.

The follow-up commits close the gaps a review of that fix surfaced. The now dead position default is removed from MAP_CONFIG, so the shared object whose mutation caused the wrong coordinates cannot be reintroduced by spreading the constant again. The onGMapsReady callback now clears gmapsLoading in both loaders, so the flag pair no longer reports a load in flight forever after a successful load. The gmapsReady listener is detached when a field unmounts, so a field removed between a failed load and a successful retry no longer initializes a map against a DOM node that no longer exists. New tests pin the injected-script guard branch (the only line coordinating with the JSP loader), assert that both fields subscribe to gmapsReady when only one injects the script, and cover the flag clearing and the unmount detach.

## PR Check

**pr-check: PASS** — tested on `802d8d6119ed0094f419e8801639bc224fb05e3e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "802d8d6119ed0094f419e8801639bc224fb05e3e"} -->
