### PR TITLE
LPD-94145 Declare the restructured chat's module dependencies

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
@@ -16,10 +16,12 @@
 		"@clayui/list": "^3.165.0",
 		"@clayui/loading-indicator": "^3.165.0",
 		"@clayui/modal": "^3.165.0",
+		"@clayui/multi-select": "^3.165.0",
 		"@clayui/panel": "^3.165.0",
 		"@clayui/provider": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",
 		"@clayui/tooltip": "^3.165.0",
+		"@liferay/frontend-js-react-web": "*",
 		"ckeditor5": "46.0.3",
 		"classnames": "2.3.1",
 		"eventsource": "^4.0.0",
@@ -27,6 +29,9 @@
 		"frontend-js-web": "*",
 		"react": "18.2.0",
 		"react-dom": "18.2.0"
+	},
+	"devDependencies": {
+		"@liferay/layout-js-components-web": "*"
 	},
 	"main": "js/index.ts",
 	"name": "@liferay/ai-hub-cell-js-components-web",

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChatBody.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChatBody.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {autoSize as AutoSize} from 'frontend-js-web';
+import {AutoSize} from 'frontend-js-web';
 import React, {useEffect, useRef} from 'react';
 
 import AIAssistantFooterDisclaimer from './components/AIAssistantFooterDisclaimer';

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0ea2f2d32ca5e3f6ecf91645c4ca8b6706f6b1a9",
+	"@generated": "2e15d9f79c4d7eb16cc0b7f1d9db952266d953e6",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,12 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/layout-js-components-web": [
+				"../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-components-web": [
 				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
@@ -38,10 +44,16 @@
 	],
 	"references": [
 		{
+			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
 			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}
 	]
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "3d7556e4c1aadc42591e52c6f717a1fe45fdd8ec",
+	"@generated": "86504f3247a7d85dc711aa82672c53913b7ca4b0",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,12 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/layout-js-components-web": [
+				"../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-components-web": [
 				"../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
@@ -40,10 +46,16 @@
 	],
 	"references": [
 		{
+			"path": "../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
 			"path": "../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}
 	]
 }


### PR DESCRIPTION
Fixes source-formatter and TypeScript failures in `ai-hub-cell-js-components-web` on top of the restructure work in this branch (#679).

The restructure added imports that were never declared in the module's `package.json`, so `ant format-source-current-branch` fails with `@liferay/no-extraneous-dependencies` and TypeScript `TS2307` (cannot find module):

- `@liferay/frontend-js-react-web` — `AIAssistantChat.tsx`, `shells/AIAssistantSidebar.tsx`
- `@clayui/multi-select` — `components/TranslateContentMessageBalloon.tsx`
- `@liferay/layout-js-components-web` — `test/js/AIAssistantChat/shells/AIAssistantSidebar.test.tsx`

It also corrects a `TS2724` in `AIAssistantChatBody.tsx`, where `frontend-js-web` was imported as `autoSize` even though the export is `AutoSize`.

Changes:

- Declare the three packages in `package.json` (`@liferay/layout-js-components-web` as a devDependency, since it is test-only).
- Regenerate the module's `tsconfig.json` files so the `@liferay/*` path mappings and project references resolve.
- Fix the `AutoSize` import.

Verified with `ant format-source-current-branch` (clean).